### PR TITLE
Move jQuery library reference to bottom

### DIFF
--- a/2018-minutes.html
+++ b/2018-minutes.html
@@ -12,7 +12,6 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
 	<link rel="icon" type="image/png" href="favicon.png">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<!--[if lt IE 9]>
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -162,6 +161,7 @@
 	</footer>
 </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script>
 // Toggle font size
 var toggleFontSize = function() {

--- a/2019-minutes.html
+++ b/2019-minutes.html
@@ -12,7 +12,6 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
 	<link rel="icon" type="image/png" href="favicon.png">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<!--[if lt IE 9]>
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -164,6 +163,7 @@
 	</footer>
 </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script>
 // Toggle font size
 var toggleFontSize = function() {

--- a/2020-minutes.html
+++ b/2020-minutes.html
@@ -12,7 +12,6 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
 	<link rel="icon" type="image/png" href="favicon.png">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<!--[if lt IE 9]>
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -162,6 +161,7 @@
 	</footer>
 </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script>
 // Toggle font size
 var toggleFontSize = function() {

--- a/2021-minutes.html
+++ b/2021-minutes.html
@@ -12,7 +12,6 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
 	<link rel="icon" type="image/png" href="favicon.png">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<!--[if lt IE 9]>
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -160,6 +159,7 @@
 	</footer>
 </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script>
 // Toggle font size
 var toggleFontSize = function() {

--- a/contact-list.html
+++ b/contact-list.html
@@ -12,7 +12,6 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
 	<link rel="icon" type="image/png" href="favicon.png">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<!--[if lt IE 9]>
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -228,6 +227,7 @@
 	| &copy; 2021 Louisa County Commission on Aging. All rights reserved.
 	</footer>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script>
 // Toggle font size
 var toggleFontSize = function() {

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
 	<link rel="icon" type="image/png" href="favicon.png">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 	<!--[if lt IE 9]>
     <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -237,6 +236,7 @@
 	</footer>
 </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script>
 // Toggle font size
 var toggleFontSize = function() {


### PR DESCRIPTION
Move the reference to the jQuery library from the head to near the end of the body. This is to speed up page loading.