### PR TITLE
improve carousel heading CSS

### DIFF
--- a/LCCA-stylesheet.css
+++ b/LCCA-stylesheet.css
@@ -491,6 +491,8 @@ li {
 }
 .news {
 	text-align: center;
+	color: orange;
+	text-shadow: 1px 1px gray;
 }
 
 


### PR DESCRIPTION
Change CSS for heading above carousel to add text shadow and change color to orange.