### PR TITLE
Add text shadow to top article links on mouseover

### DIFF
--- a/LCCA-stylesheet.css
+++ b/LCCA-stylesheet.css
@@ -296,7 +296,9 @@ a {
 a:hover {
 	text-decoration: underline;
 }
-
+.banner-article a:hover {
+	text-shadow: 1px 1px grey;
+}
 abbr {
 	text-decoration: none !important;
 	font-variant: none;


### PR DESCRIPTION
Add text shadow to article links near top of page whenever the user mouses over them.