### PR TITLE
Remove banner note re: old event

### DIFF
--- a/2018-minutes.html
+++ b/2018-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Website for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-07-26" />
+	<meta name="dcterms.modified" content="2021-08-02" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -39,10 +39,6 @@
 	<div class="right size">
 		<button id="toggleButton" class="toggle" onclick="toggleFontSize()">INCREASE FONT SIZE</button>
 	</div>
-</div>
-<div class="banner-note">
-	The Commission on Aging will have a table at the Louisa County Agricultural Fair from July 29th to the 31st.
-	<a href="http://www.louisacountyagfair.com/" target="_blank">Order tickets now</a>!
 </div>
 <div class="banner-article">
 	<a href="https://www.agingtogether.org/uploads/1/3/0/9/130908318/2021_summer_caregiver_series.pdf" target="_blank">Webinars: Summer Caregiver Series</a>

--- a/2019-minutes.html
+++ b/2019-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Website for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-07-26" />
+	<meta name="dcterms.modified" content="2021-08-02" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -39,10 +39,6 @@
 	<div class="right size">
 		<button id="toggleButton" class="toggle" onclick="toggleFontSize()">INCREASE FONT SIZE</button>
 	</div>
-</div>
-<div class="banner-note">
-	The Commission on Aging will have a table at the Louisa County Agricultural Fair from July 29th to the 31st.
-	<a href="http://www.louisacountyagfair.com/" target="_blank">Order tickets now</a>!
 </div>
 <div class="banner-article">
 	<a href="https://www.agingtogether.org/uploads/1/3/0/9/130908318/2021_summer_caregiver_series.pdf" target="_blank">Webinars: Summer Caregiver Series</a>

--- a/2020-minutes.html
+++ b/2020-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Website for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-07-26" />
+	<meta name="dcterms.modified" content="2021-08-02" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -39,10 +39,6 @@
 	<div class="right size">
 		<button id="toggleButton" class="toggle" onclick="toggleFontSize()">INCREASE FONT SIZE</button>
 	</div>
-</div>
-<div class="banner-note">
-	The Commission on Aging will have a table at the Louisa County Agricultural Fair from July 29th to the 31st.
-	<a href="http://www.louisacountyagfair.com/" target="_blank">Order tickets now</a>!
 </div>
 <div class="banner-article">
 	<a href="https://www.agingtogether.org/uploads/1/3/0/9/130908318/2021_summer_caregiver_series.pdf" target="_blank">Webinars: Summer Caregiver Series</a>

--- a/2021-minutes.html
+++ b/2021-minutes.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Website for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-07-26" />
+	<meta name="dcterms.modified" content="2021-08-02" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -39,10 +39,6 @@
 	<div class="right size">
 		<button id="toggleButton" class="toggle" onclick="toggleFontSize()">INCREASE FONT SIZE</button>
 	</div>
-</div>
-<div class="banner-note">
-	The Commission on Aging will have a table at the Louisa County Agricultural Fair from July 29th to the 31st.
-	<a href="http://www.louisacountyagfair.com/" target="_blank">Order tickets now</a>!
 </div>
 <div class="banner-article">
 	<a href="https://www.agingtogether.org/uploads/1/3/0/9/130908318/2021_summer_caregiver_series.pdf" target="_blank">Webinars: Summer Caregiver Series</a>

--- a/contact-list.html
+++ b/contact-list.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="Website for the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry" />
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-07-26" />
+	<meta name="dcterms.modified" content="2021-08-02" />
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LCCA-stylesheet.css" />
@@ -39,10 +39,6 @@
 	<div class="right size">
 	    <button id="toggleButton" class="toggle" onclick="toggleFontSize()">INCREASE FONT SIZE</button>
 	</div>
-</div>
-<div class="banner-note">
-	The Commission on Aging will have a table at the Louisa County Agricultural Fair from July 29th to the 31st.
-	<a href="http://www.louisacountyagfair.com/" target="_blank">Order tickets now</a>!
 </div>
 <div class="banner-article">
 	<a href="https://www.agingtogether.org/uploads/1/3/0/9/130908318/2021_summer_caregiver_series.pdf" target="_blank">Webinars: Summer Caregiver Series</a>

--- a/index.html
+++ b/index.html
@@ -40,10 +40,6 @@
 		<button id="toggleButton" class="toggle" onclick="toggleFontSize()">INCREASE FONT SIZE</button>
 	</div>
 </div>
-<div class="banner-note">
-	The Commission on Aging will have a table at the Louisa County Agricultural Fair from July 29th to the 31st.
-	<a href="http://www.louisacountyagfair.com/" target="_blank">Order tickets now</a>!
-</div>
 <div class="banner-article">
 	<a href="https://www.agingtogether.org/uploads/1/3/0/9/130908318/2021_summer_caregiver_series.pdf" target="_blank">Webinars: Summer Caregiver Series</a>
 	&nbsp;&nbsp;|&nbsp;&nbsp;


### PR DESCRIPTION
Remove banner note referring to Louisa County Agricultural Fair, which is already complete.