### PR TITLE
Change "heading" to "header" in HTML/CSS

### DIFF
--- a/LCCA-stylesheet.css
+++ b/LCCA-stylesheet.css
@@ -467,7 +467,7 @@ form {
 	margin: 0 -1em 0 0;
 }
 
-.heading {
+.header {
 	border: 5px groove gray;
 	background: linear-gradient(#009900 15%, #006600 100%); /*linear-gradient(#009900 15%, #003300 100%);*/
     min-height: 8.5em;

--- a/Little-Yellow-Books.html
+++ b/Little-Yellow-Books.html
@@ -21,7 +21,7 @@
 <body>
 <div class="container">
 
-<div class="heading">
+<div class="header">
 	<h1>
 		<a href="#" class="title">
 			<img class="left small" src="yellow-phonebook.webp" alt="Louisa County Seal" />
@@ -56,18 +56,18 @@
 <menu>
 	<li>
 		<a href="" target="_blank">
-		<img src="Albemarle-County-seal.png" class="menu-img" alt="Albemarle County seal" />
-		<span class="bottom-menu">
-		ALBEMARLE COUNTY
-		</span>
+			<img src="Albemarle-County-seal.png" class="menu-img" alt="Albemarle County seal" />
+			<span class="bottom-menu">
+			ALBEMARLE COUNTY
+			</span>
 		</a>
 	</li>
 	<li>
 		<a href="" target="_blank">
-		<img src="Charlottesville-seal.png" class="menu-img" alt="Charlottesville seal"/>
-		<span class="bottom-menu">
-		CHARLOTTESVILLE
-		</span>
+			<img src="Charlottesville-seal.png" class="menu-img" alt="Charlottesville seal"/>
+			<span class="bottom-menu">
+			CHARLOTTESVILLE
+			</span>
 		</a>
 	</li>
 	<li>
@@ -88,18 +88,18 @@
 	</li>
 	<li>
 		<a href="https://louisa-county-coa.github.io/Little-Yellow-Book.pdf"  target="_blank">
-		<img src="Louisa-County-Seal-color.webp" class="menu-img" alt="Louisa County Seal"/>
-		<span class="bottom-menu">
-		LOUISA COUNTY
-		</span>
+			<img src="Louisa-County-Seal-color.webp" class="menu-img" alt="Louisa County Seal"/>
+			<span class="bottom-menu">
+			LOUISA COUNTY
+			</span>
 		</a>
 	</li>
 	<li>
 		<a href=""  target="_blank">
-		<img src="Nelson-county-seal.png" class="menu-img" alt="Nelson County Seal"/>
-		<span class="bottom-menu">
-		NELSON COUNTY
-		</span>
+			<img src="Nelson-county-seal.png" class="menu-img" alt="Nelson County Seal"/>
+			<span class="bottom-menu">
+			NELSON COUNTY
+			</span>
 		</a>
 	</li>
 </menu>


### PR DESCRIPTION
Change "heading" to "header" in HTML and CSS to be more precise.