### PR TITLE
Fix heading/header naming in CSS

### DIFF
--- a/LYB-stylesheet.css
+++ b/LYB-stylesheet.css
@@ -174,7 +174,7 @@ footer {
 	padding: 0.625em;
 }
 
-.heading {
+.header {
 	border: 5px groove gray;
 	background: linear-gradient(#ffd24d 25%, #e6ac00 85%);
     min-height: 8.5em;

--- a/Little-Yellow-Books.html
+++ b/Little-Yellow-Books.html
@@ -37,8 +37,6 @@
 		</div>
 	</div>
 </div>
-<div>
-</div>
 
 <div>
 	<section class="content">
@@ -53,6 +51,7 @@
 	</section>
 </div>
 <hr>
+<div>
 <menu>
 	<li>
 		<a href="" target="_blank">
@@ -103,6 +102,7 @@
 		</a>
 	</li>
 </menu>
+</div>
 <hr>
 <div>
 	<footer>


### PR DESCRIPTION
Change "heading" in CSS to "header" to be more accurate and match HTML. Also add div around menu.