### PR TITLE
Remove unnecessary span elements

### DIFF
--- a/Little-Yellow-Books.html
+++ b/Little-Yellow-Books.html
@@ -56,49 +56,37 @@
 	<li>
 		<a href="" target="_blank">
 			<img src="Albemarle-County-seal.png" class="menu-img" alt="Albemarle County seal" />
-			<span>
 			ALBEMARLE COUNTY
-			</span>
 		</a>
 	</li>
 	<li>
 		<a href="" target="_blank">
 			<img src="Charlottesville-seal.png" class="menu-img" alt="Charlottesville seal"/>
-			<span>
 			CHARLOTTESVILLE
-			</span>
 		</a>
 	</li>
 	<li>
 		<a href=""  target="_blank">
 			<img src="Fluvanna-county-seal.png" class="menu-img" alt="Fluvanna County seal"/>
-			<span>
 			FLUVANNA COUNTY
-			</span>
 		</a>
 	</li>
 	<li>
 		<a href=""  target="_blank">
 			<img src="Greene-County-seal2.gif" class="menu-img" alt="Greene County seal"/>
-			<span>
 			GREENE COUNTY
-			</span>
 		</a>
 	</li>
 	<li>
 		<a href="https://louisa-county-coa.github.io/Little-Yellow-Book.pdf"  target="_blank">
 			<img src="Louisa-County-Seal-color.webp" class="menu-img" alt="Louisa County Seal"/>
-			<span>
 			LOUISA COUNTY
-			</span>
 		</a>
 	</li>
 	<li>
 		<a href=""  target="_blank">
 			<img src="Nelson-county-seal.png" class="menu-img" alt="Nelson County Seal"/>
-			<span>
 			NELSON COUNTY
-			</span>
 		</a>
 	</li>
 </menu>


### PR DESCRIPTION
Remove span elements from LYB site menu; currently they do nothing.