### PR TITLE
Fix header class name in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <body>
 <div id="container">
 
-<div class="heading">
+<div class="header">
 	<h1>
 		<a href="index.html" class="title">
 			<img class="left small" src="Louisa-County-Seal-color.webp" alt="Louisa County Seal" />


### PR DESCRIPTION
Change class name from "heading" to "header" in HTML to match CSS.