### PR TITLE
Fix capitalization errors

### DIFF
--- a/Little-Yellow-Books.html
+++ b/Little-Yellow-Books.html
@@ -8,7 +8,7 @@
 	from the Louisa County Commission on Aging.">
 	<meta name="author" content="Brendan Ferreri-Hanberry">
 	<link rel="schema.dcterms" href="http://purl.org/dc/terms/">
-	<meta name="dcterms.modified" content="2021-08-26">
+	<meta name="dcterms.modified" content="2021-09-13">
 	<meta name="viewport" content="width=device-width initial-scale=1" >
 	<meta charset="UTF-8">
 	<link rel="stylesheet" type="text/css" href="LYB-stylesheet.css">
@@ -55,7 +55,7 @@
 <ul class="menu">
 	<li>
 		<a href="" target="_blank">
-			<img src="Albemarle-County-seal.png" class="menu-img" alt="Albemarle County seal" />
+			<img src="Albemarle-County-Seal.png" class="menu-img" alt="Albemarle County seal" />
 			ALBEMARLE COUNTY
 		</a>
 	</li>
@@ -67,7 +67,7 @@
 	</li>
 	<li>
 		<a href=""  target="_blank">
-			<img src="Fluvanna-county-seal.png" class="menu-img" alt="Fluvanna County seal"/>
+			<img src="Fluvanna-County-seal.png" class="menu-img" alt="Fluvanna County seal"/>
 			FLUVANNA COUNTY
 		</a>
 	</li>
@@ -85,7 +85,7 @@
 	</li>
 	<li>
 		<a href=""  target="_blank">
-			<img src="Nelson-county-seal.png" class="menu-img" alt="Nelson County Seal"/>
+			<img src="Nelson-County-seal.png" class="menu-img" alt="Nelson County Seal"/>
 			NELSON COUNTY
 		</a>
 	</li>


### PR DESCRIPTION
Fix capitalization errors in filenames that were causing problems displaying images.